### PR TITLE
add option to pass dt for each update step:

### DIFF
--- a/ahrs/filters/angular.py
+++ b/ahrs/filters/angular.py
@@ -371,7 +371,7 @@ class AngularRate:
             Q[t] = self.update(Q[t-1], self.gyr[t], method=self.method, order=self.order)
         return Q
 
-    def update(self, q: np.ndarray, gyr: np.ndarray, method: str = 'closed', order: int = 1) -> np.ndarray:
+    def update(self, q: np.ndarray, gyr: np.ndarray, method: str = 'closed', order: int = 1, dt: float = None) -> np.ndarray:
         """Update the quaternion estimation
 
         Estimate quaternion :math:`\\mathbf{q}_{t+1}` from given a-priori
@@ -408,6 +408,8 @@ class AngularRate:
             Estimation method to use. Options are: ``'series'`` or ``'closed'``.
         order : int
             Truncation order, if method ``'series'`` is used.
+        dt : float, default: None
+            Time step, in seconds, between consecutive Quaternions.
 
         Returns
         -------
@@ -436,6 +438,7 @@ class AngularRate:
                [-0.92504595, -0.23174096,  0.20086376, -0.22414251]])
 
         """
+        dt = self.Dt if dt is None else dt
         if method.lower() not in ['series', 'closed']:
             raise ValueError(f"Invalid method '{method}'. Try 'series' or 'closed'")
         q = np.copy(q)
@@ -448,11 +451,11 @@ class AngularRate:
             [gyr[2],  gyr[1], -gyr[0],     0.0]])
         if method.lower() == 'closed':
             w = np.linalg.norm(gyr)
-            A = np.cos(w*self.Dt/2.0)*np.eye(4) + np.sin(w*self.Dt/2.0)*Omega/w
+            A = np.cos(w*dt/2.0)*np.eye(4) + np.sin(w*dt/2.0)*Omega/w
         else:
             if order < 0:
                 raise ValueError(f"The order must be an int equal to or greater than 0. Got {order}")
-            S = 0.5 * self.Dt * Omega
+            S = 0.5 * dt * Omega
             A = np.identity(4)
             for i in range(1, order+1):
                 A += S**i / np.math.factorial(i)

--- a/ahrs/filters/aqua.py
+++ b/ahrs/filters/aqua.py
@@ -936,7 +936,7 @@ class AQUA:
             return q/np.linalg.norm(q)
         return q_acc
 
-    def updateIMU(self, q: np.ndarray, gyr: np.ndarray, acc: np.ndarray) -> np.ndarray:
+    def updateIMU(self, q: np.ndarray, gyr: np.ndarray, acc: np.ndarray, dt: float = None) -> np.ndarray:
         """
         Quaternion Estimation with a IMU architecture.
 
@@ -958,6 +958,8 @@ class AQUA:
             Sample of tri-axial Gyroscope in rad/s.
         acc : numpy.ndarray
             Sample of tri-axial Accelerometer in m/s^2
+        dt : float, default: None
+            Time step, in seconds, between consecutive Quaternions.
 
         Returns
         -------
@@ -965,11 +967,12 @@ class AQUA:
             Estimated quaternion.
 
         """
+        dt = self.Dt if dt is None else dt
         if gyr is None or not np.linalg.norm(gyr) > 0:
             return q
         # PREDICTION
         qDot = 0.5*self.Omega(gyr) @ q                      # Quaternion derivative (eq. 39)
-        qInt = q + qDot*self.Dt                             # Quaternion integration (eq. 42)
+        qInt = q + qDot*dt                             # Quaternion integration (eq. 42)
         qInt /= np.linalg.norm(qInt)
         # CORRECTION
         a_norm = np.linalg.norm(acc)
@@ -984,7 +987,7 @@ class AQUA:
         q_prime = q_prod(qInt, q_acc)                       # (eq. 53)
         return q_prime/np.linalg.norm(q_prime)
 
-    def updateMARG(self, q: np.ndarray, gyr: np.ndarray, acc: np.ndarray, mag: np.ndarray) -> np.ndarray:
+    def updateMARG(self, q: np.ndarray, gyr: np.ndarray, acc: np.ndarray, mag: np.ndarray, dt: float = None) -> np.ndarray:
         """
         Quaternion Estimation with a MARG architecture.
 
@@ -1010,6 +1013,8 @@ class AQUA:
             Sample of tri-axial Accelerometer in m/s^2
         mag : numpy.ndarray
             Sample of tri-axial Magnetometer in mT
+        dt : float, default: None
+            Time step, in seconds, between consecutive Quaternions.
 
         Returns
         -------
@@ -1017,11 +1022,12 @@ class AQUA:
             Estimated quaternion.
 
         """
+        dt = self.Dt if dt is None else dt
         if gyr is None or not np.linalg.norm(gyr)>0:
             return q
         # PREDICTION
         qDot = 0.5*self.Omega(gyr) @ q                      # Quaternion derivative (eq. 39)
-        qInt = q + qDot*self.Dt                             # Quaternion integration (eq. 42)
+        qInt = q + qDot*dt                             # Quaternion integration (eq. 42)
         qInt /= np.linalg.norm(qInt)
         # CORRECTION
         a_norm = np.linalg.norm(acc)

--- a/ahrs/filters/fourati.py
+++ b/ahrs/filters/fourati.py
@@ -321,7 +321,7 @@ class Fourati:
             Q[t] = self.update(Q[t-1], self.gyr[t], self.acc[t], self.mag[t])
         return Q
 
-    def update(self, q: np.ndarray, gyr: np.ndarray, acc: np.ndarray, mag: np.ndarray) -> np.ndarray:
+    def update(self, q: np.ndarray, gyr: np.ndarray, acc: np.ndarray, mag: np.ndarray, dt: float = None) -> np.ndarray:
         """
         Quaternion Estimation with a MARG architecture.
 
@@ -335,6 +335,8 @@ class Fourati:
             Sample of tri-axial Accelerometer in m/s^2
         mag : numpy.ndarray
             Sample of tri-axial Magnetometer in mT
+        dt : float, default: None
+            Time step, in seconds, between consecutive Quaternions.
 
         Returns
         -------
@@ -342,6 +344,7 @@ class Fourati:
             Estimated quaternion.
 
         """
+        dt = self.Dt if dt is None else dt
         if gyr is None or not np.linalg.norm(gyr)>0:
             return q
         qDot = 0.5 * q_prod(q, [0, *gyr])                           # (eq. 5)
@@ -359,5 +362,5 @@ class Fourati:
             K = self.gain*np.linalg.inv(X.T@X + lam*np.eye(3))@X.T  # Filter gain (eq. 24)
             Delta = [1, *K@dq]                                      # Correction term (eq. 25)
             qDot = q_prod(qDot, Delta)                              # Corrected quaternion rate (eq. 7)
-        q += qDot*self.Dt
+        q += qDot*dt
         return q/np.linalg.norm(q)

--- a/ahrs/filters/madgwick.py
+++ b/ahrs/filters/madgwick.py
@@ -557,7 +557,7 @@ class Madgwick:
             Q[t] = self.updateMARG(Q[t-1], self.gyr[t], self.acc[t], self.mag[t])
         return Q
 
-    def updateIMU(self, q: np.ndarray, gyr: np.ndarray, acc: np.ndarray) -> np.ndarray:
+    def updateIMU(self, q: np.ndarray, gyr: np.ndarray, acc: np.ndarray, dt: float = None) -> np.ndarray:
         """
         Quaternion Estimation with IMU architecture.
 
@@ -569,6 +569,8 @@ class Madgwick:
             Sample of tri-axial Gyroscope in rad/s
         acc : numpy.ndarray
             Sample of tri-axial Accelerometer in m/s^2
+        dt : float, default: None
+            Time step, in seconds, between consecutive Quaternions.
 
         Returns
         -------
@@ -601,6 +603,7 @@ class Madgwick:
         _assert_iterables(q, 'Quaternion')
         _assert_iterables(gyr, 'Tri-axial gyroscope sample')
         _assert_iterables(acc, 'Tri-axial accelerometer sample')
+        dt = self.Dt if dt is None else dt
         if gyr is None or not np.linalg.norm(gyr) > 0:
             return q
         qDot = 0.5 * q_prod(q, [0, *gyr])                           # (eq. 12)
@@ -619,11 +622,11 @@ class Madgwick:
             gradient = J.T@f                                        # (eq. 34)
             gradient /= np.linalg.norm(gradient)
             qDot -= self.gain*gradient                              # (eq. 33)
-        q += qDot*self.Dt                                           # (eq. 13)
+        q += qDot*dt                                           # (eq. 13)
         q /= np.linalg.norm(q)
         return q
 
-    def updateMARG(self, q: np.ndarray, gyr: np.ndarray, acc: np.ndarray, mag: np.ndarray) -> np.ndarray:
+    def updateMARG(self, q: np.ndarray, gyr: np.ndarray, acc: np.ndarray, mag: np.ndarray, dt: float = None) -> np.ndarray:
         """
         Quaternion Estimation with a MARG architecture.
 
@@ -637,6 +640,8 @@ class Madgwick:
             Sample of tri-axial Accelerometer in m/s^2
         mag : numpy.ndarray
             Sample of tri-axial Magnetometer in nT
+        dt : float, default: None
+            Time step, in seconds, between consecutive Quaternions.
 
         Returns
         -------
@@ -671,6 +676,7 @@ class Madgwick:
         _assert_iterables(gyr, 'Tri-axial gyroscope sample')
         _assert_iterables(acc, 'Tri-axial accelerometer sample')
         _assert_iterables(mag, 'Tri-axial magnetometer sample')
+        dt = self.Dt if dt is None else dt
         if gyr is None or not np.linalg.norm(gyr) > 0:
             return q
         if mag is None or not np.linalg.norm(mag) > 0:
@@ -701,6 +707,6 @@ class Madgwick:
             gradient = J.T@f                                        # (eq. 34)
             gradient /= np.linalg.norm(gradient)
             qDot -= self.gain*gradient                              # (eq. 33)
-        q += qDot*self.Dt                                           # (eq. 13)
+        q += qDot*dt                                          # (eq. 13)
         q /= np.linalg.norm(q)
         return q

--- a/ahrs/filters/mahony.py
+++ b/ahrs/filters/mahony.py
@@ -450,7 +450,7 @@ class Mahony:
             Q[t] = self.updateMARG(Q[t-1], self.gyr[t], self.acc[t], self.mag[t])
         return Q
 
-    def updateIMU(self, q: np.ndarray, gyr: np.ndarray, acc: np.ndarray) -> np.ndarray:
+    def updateIMU(self, q: np.ndarray, gyr: np.ndarray, acc: np.ndarray, dt: float = None) -> np.ndarray:
         """
         Attitude Estimation with a IMU architecture.
 
@@ -462,6 +462,8 @@ class Mahony:
             Sample of tri-axial Gyroscope in rad/s.
         acc : numpy.ndarray
             Sample of tri-axial Accelerometer in m/s^2.
+        dt : float, default: None
+            Time step, in seconds, between consecutive Quaternions.
 
         Returns
         -------
@@ -476,6 +478,7 @@ class Mahony:
         ...     Q[t] = orientation.updateIMU(Q[t-1], gyr=gyro_data[t], acc=acc_data[t])
 
         """
+        dt = self.Dt if dt is None else dt
         if gyr is None or not np.linalg.norm(gyr)>0:
             return q
         Omega = np.copy(gyr)
@@ -489,11 +492,11 @@ class Mahony:
             Omega = Omega - b + self.k_P*omega_mes  # Gyro correction
         p = np.array([0.0, *Omega])
         qDot = 0.5*q_prod(q, p)                     # Rate of change of quaternion (eqs. 45 and 48b)
-        q += qDot*self.Dt                           # Update orientation
+        q += qDot*dt                           # Update orientation
         q /= np.linalg.norm(q)                      # Normalize Quaternion (Versor)
         return q
 
-    def updateMARG(self, q: np.ndarray, gyr: np.ndarray, acc: np.ndarray, mag: np.ndarray) -> np.ndarray:
+    def updateMARG(self, q: np.ndarray, gyr: np.ndarray, acc: np.ndarray, mag: np.ndarray, dt: float = None) -> np.ndarray:
         """
         Attitude Estimation with a MARG architecture.
 
@@ -507,6 +510,8 @@ class Mahony:
             Sample of tri-axial Accelerometer in m/s^2.
         mag : numpy.ndarray
             Sample of tri-axail Magnetometer in uT.
+        dt : float, default: None
+            Time step, in seconds, between consecutive Quaternions.
 
         Returns
         -------
@@ -521,6 +526,7 @@ class Mahony:
         ...     Q[t] = orientation.updateMARG(Q[t-1], gyr=gyro_data[t], acc=acc_data[t], mag=mag_data[t])
 
         """
+        dt = self.Dt if dt is None else dt
         if gyr is None or not np.linalg.norm(gyr)>0:
             return q
         Omega = np.copy(gyr)
@@ -543,6 +549,6 @@ class Mahony:
             Omega = Omega - b + self.k_P*omega_mes  # Gyro correction
         p = np.array([0.0, *Omega])
         qDot = 0.5*q_prod(q, p)                     # Rate of change of quaternion (eqs. 45 and 48b)
-        q += qDot*self.Dt                           # Update orientation
+        q += qDot*dt                           # Update orientation
         q /= np.linalg.norm(q)                      # Normalize Quaternion (Versor)
         return q


### PR DESCRIPTION
-adds option to pass a different dt for each update step on filters which do gyroscope integration
-relevant for real data, where sampling time might be inconsistent
-defaults to constant value defined on \_\_init\_\_ if no value is specified in the update step