### PR TITLE
fixing order of roll, pitch, yaw in Quaternion.from_rpy()

### DIFF
--- a/ahrs/common/quaternion.py
+++ b/ahrs/common/quaternion.py
@@ -1814,7 +1814,7 @@ class Quaternion(np.ndarray):
         for angle in angles:
             if angle < -2.0* np.pi or angle > 2.0 * np.pi:
                 raise ValueError(f"Expected `angles` must be in the range [-2pi, 2pi], got {angles}.")
-        yaw, pitch, roll = angles
+        roll, pitch, yaw = angles
         cy = np.cos(0.5*yaw)
         sy = np.sin(0.5*yaw)
         cp = np.cos(0.5*pitch)


### PR DESCRIPTION
using from_angles() to create a quaternion and converting it back using to_angles() changed the order of angles compared to the initial input. The method from_rpy() was interpreting the input as yaw, pitch, roll.