### PR TITLE
fixing unwanted compass rotations at 180deg heading

### DIFF
--- a/ahrs/filters/complementary.py
+++ b/ahrs/filters/complementary.py
@@ -276,5 +276,8 @@ class Complementary:
         q_omega = self.attitude_propagation(q, gyr, dt)
         q_am = self.am_estimation(acc, mag)
         # Complementary Estimation
-        q = (1.0 - self.gain)*q_omega + self.gain*q_am
+        if np.linalg.norm(q_omega + q_am) < np.sqrt(2):
+            q = (1.0 - self.gain)*q_omega - self.gain*q_am
+        else:
+            q = (1.0 - self.gain)*q_omega + self.gain*q_am
         return q/np.linalg.norm(q)


### PR DESCRIPTION
Problem could be reproduced with gain=0.5, q_am=[ 0.00872654,  0.,  0., -0.99996192] (yaw=-179 deg), q_omega=[0.00872654, 0., 0., 0.99996192] (yaw=179 deg). Result was [0, 0, 0, 0] (yaw=0 deg). Now it is [0., 0., 0., 0.99996192] (yaw=180 deg). When streaming sensor data to a virtual compass instrument, the needle performed an additional rotation each time it passed the 180 deg position which is fixed now.