### PR TITLE
Fix loop condition in FLAE-newton implementation

### DIFF
--- a/ahrs/filters/flae.py
+++ b/ahrs/filters/flae.py
@@ -512,9 +512,10 @@ class FLAE:
         t2 = -8*np.linalg.det(H.T)
         t3 = np.linalg.det(W)
         if method.lower() == 'newton':
-            lam = lam_old = 1.0
+            lam = 1.0
+            lam_old = 0.0
             i = 0
-            while abs(lam_old-lam) > 1e-8 or i <= 30:
+            while abs(lam_old-lam) > 1e-8 and i < 6:
                 lam_old = lam
                 f = lam**4 + t1*lam**2 + t2*lam + t3        # (eq. 48)
                 fp = 4*lam**3 + 2*t1*lam + t2               # (eq. 50)


### PR DESCRIPTION
The current implementation has implemented wrong the condition for checking whether the eigen value search using the Newton-method has converged. The implementation calculates the convergence criteria wrong at the first iteration and then always performs 31 iterations due to the 'OR' in the while-condition. According to the original FLAE paper, the algorithm should converge in less than 4 iterations so fixing this is should speed up the implementation a bit.
There seems to be similar bug also in the original MATLAB implementation.