### PR TITLE
Update madgwick.py/Typo magnetic field unit

### DIFF
--- a/ahrs/filters/madgwick.py
+++ b/ahrs/filters/madgwick.py
@@ -256,7 +256,7 @@ class Madgwick:
         acc : numpy.ndarray
             Sample of tri-axial Accelerometer in m/s^2
         mag : numpy.ndarray
-            Sample of tri-axial Magnetometer in T
+            Sample of tri-axial Magnetometer in mT
 
         Returns
         -------


### PR DESCRIPTION
def updateMARG specificies mag data to be in "T" but likely should be "mT" as in the class docstring